### PR TITLE
fix: Fix schema inference for default method

### DIFF
--- a/R/array.R
+++ b/R/array.R
@@ -18,7 +18,7 @@ as_geoarrow_array <- function(x, ..., schema = NULL) {
 #' @export
 as_geoarrow_array.default <- function(x, ..., schema = NULL) {
   if (is.null(schema)) {
-    schema <- infer_nanoarrow_schema(x)
+    schema <- infer_geoarrow_schema(x)
   }
 
   wk::wk_handle(x, geoarrow_writer(schema))

--- a/tests/testthat/test-pkg-sf.R
+++ b/tests/testthat/test-pkg-sf.R
@@ -61,6 +61,19 @@ test_that("arrow package objects can be converted to and from sf objects", {
   expect_identical(sf_inferred$extension_name(), "geoarrow.point")
 })
 
+test_that("sf objects work with as_geoarrow_array()", {
+  skip_if_not_installed("sf")
+
+  sfc <- sf::st_sfc(sf::st_point(c(0, 1)))
+  sf <- sf::st_as_sf(data.frame(geometry = sfc))
+
+  array <- as_geoarrow_array(sf)
+  parsed <- geoarrow_schema_parse(infer_nanoarrow_schema(array))
+  expect_identical(parsed$extension_name, "geoarrow.point")
+  expect_identical(nanoarrow::convert_buffer(array$children$x$buffers[[2]]), 0)
+  expect_identical(nanoarrow::convert_buffer(array$children$y$buffers[[2]]), 1)
+})
+
 test_that("convert_array() works for sfc", {
   skip_if_not_installed("sf")
 


### PR DESCRIPTION
Closes #32.

Good catch!

``` r
library(geoarrow)
library(sf)
#> Linking to GEOS 3.11.0, GDAL 3.5.3, PROJ 9.1.0; sf_use_s2() is TRUE

sf_obj <- data.frame(x = 1:5, y = 6:10) |> 
  sf::st_as_sf(coords = c("x", "y"), crs = "EPSG:3857")

# Now works
as_geoarrow_array(sf_obj)
#> <nanoarrow_array geoarrow.point{struct}[5]>
#>  $ length    : int 5
#>  $ null_count: int 0
#>  $ offset    : int 0
#>  $ buffers   :List of 1
#>   ..$ :<nanoarrow_buffer validity<bool>[0][0 b]> ``
#>  $ children  :List of 2
#>   ..$ x:<nanoarrow_array double[5]>
#>   .. ..$ length    : int 5
#>   .. ..$ null_count: int 0
#>   .. ..$ offset    : int 0
#>   .. ..$ buffers   :List of 2
#>   .. .. ..$ :<nanoarrow_buffer validity<bool>[0][0 b]> ``
#>   .. .. ..$ :<nanoarrow_buffer data<double>[5][40 b]> `1 2 3 4 5`
#>   .. ..$ dictionary: NULL
#>   .. ..$ children  : list()
#>   ..$ y:<nanoarrow_array double[5]>
#>   .. ..$ length    : int 5
#>   .. ..$ null_count: int 0
#>   .. ..$ offset    : int 0
#>   .. ..$ buffers   :List of 2
#>   .. .. ..$ :<nanoarrow_buffer validity<bool>[0][0 b]> ``
#>   .. .. ..$ :<nanoarrow_buffer data<double>[5][40 b]> `6 7 8 9 10`
#>   .. ..$ dictionary: NULL
#>   .. ..$ children  : list()
#>  $ dictionary: NULL

# Also works...slightly differently (also gives attributes)
nanoarrow::as_nanoarrow_array(sf_obj)
#> <nanoarrow_array struct[5]>
#>  $ length    : int 5
#>  $ null_count: int 0
#>  $ offset    : int 0
#>  $ buffers   :List of 1
#>   ..$ :<nanoarrow_buffer validity<bool>[0][0 b]> ``
#>  $ children  :List of 1
#>   ..$ geometry:<nanoarrow_array geoarrow.point{struct}[5]>
#>   .. ..$ length    : int 5
#>   .. ..$ null_count: int 0
#>   .. ..$ offset    : int 0
#>   .. ..$ buffers   :List of 1
#>   .. .. ..$ :<nanoarrow_buffer validity<bool>[0][0 b]> ``
#>   .. ..$ children  :List of 2
#>   .. .. ..$ x:<nanoarrow_array double[5]>
#>   .. .. .. ..$ length    : int 5
#>   .. .. .. ..$ null_count: int 0
#>   .. .. .. ..$ offset    : int 0
#>   .. .. .. ..$ buffers   :List of 2
#>   .. .. .. .. ..$ :<nanoarrow_buffer validity<bool>[0][0 b]> ``
#>   .. .. .. .. ..$ :<nanoarrow_buffer data<double>[5][40 b]> `1 2 3 4 5`
#>   .. .. .. ..$ dictionary: NULL
#>   .. .. .. ..$ children  : list()
#>   .. .. ..$ y:<nanoarrow_array double[5]>
#>   .. .. .. ..$ length    : int 5
#>   .. .. .. ..$ null_count: int 0
#>   .. .. .. ..$ offset    : int 0
#>   .. .. .. ..$ buffers   :List of 2
#>   .. .. .. .. ..$ :<nanoarrow_buffer validity<bool>[0][0 b]> ``
#>   .. .. .. .. ..$ :<nanoarrow_buffer data<double>[5][40 b]> `6 7 8 9 10`
#>   .. .. .. ..$ dictionary: NULL
#>   .. .. .. ..$ children  : list()
#>   .. ..$ dictionary: NULL
#>  $ dictionary: NULL
```

<sup>Created on 2024-01-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>