### PR TITLE
chore: Update vendored geoarrow-c

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,5 @@
 ^codecov\.yml$
 ^README\.Rmd$
 ^\.covrignore$
+^compile_commands\.json$
+^\.cache$

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .Rproj.user
 .Rhistory
 .vscode
+compile_commands.json
+.cache

--- a/vendor-geoarrow.sh
+++ b/vendor-geoarrow.sh
@@ -1,7 +1,7 @@
 
 rm src/geoarrow*
 
-GEOARROW_C_REF="bb2d093d6833a98f9f6bf42677245b3feeb3e5d1"
+GEOARROW_C_REF="7d9dc2f1d30b4f01341773cc4240047044134837"
 
 curl -L \
     "https://github.com/geoarrow/geoarrow-c/archive/${GEOARROW_C_REF}.zip" \

--- a/vendor-geoarrow.sh
+++ b/vendor-geoarrow.sh
@@ -1,7 +1,7 @@
 
 rm src/geoarrow*
 
-GEOARROW_C_REF="d3ad6e4fe28fc88d714b3805cc425462125487f4"
+GEOARROW_C_REF="bb2d093d6833a98f9f6bf42677245b3feeb3e5d1"
 
 curl -L \
     "https://github.com/geoarrow/geoarrow-c/archive/${GEOARROW_C_REF}.zip" \


### PR DESCRIPTION
Fixes #34 (by updating vendored geoarrow-c with the fix).

``` r
library(httr2)
library(serdesri)
requireNamespace("geoarrow")
#> Loading required namespace: geoarrow
furl <- "https://services.arcgis.com/P3ePLMYs2RVChkJx/ArcGIS/rest/services/USA_Counties_Generalized_Boundaries/FeatureServer/0"
url <- paste0(furl, "/query?where=1=1&outFields=*&f=json&resultRecordCount=100")
req <- httr2::request(url)
resp <- httr2::req_perform(req)
json <- httr2::resp_body_string(resp)

res <- parse_esri_json_raw_geoarrow(resp$body, 2)
tibble::as_tibble(res)["geometry"]
#> # A tibble: 100 × 1
#>    geometry                                                                
#>    <grrw_vct>                                                              
#>  1 <POLYGON ((-86.8206699 32.3473096, -86.8144596 32.3704109, -86.8457109 >
#>  2 <POLYGON ((-87.9730898 31.1648225, -87.9371011 31.1734568, -87.9414731 >
#>  3 <POLYGON ((-85.7433728 31.6262405, -85.7172048 31.6792371, -85.7007416 >
#>  4 <POLYGON ((-87.4198556 33.0117731, -87.3153228 33.0120969, -87.3141403 >
#>  5 <POLYGON ((-86.9679945 33.8604547, -86.9266653 33.8722758, -86.9191046 >
#>  6 <POLYGON ((-85.4113957 32.1555123, -85.411365 32.1454725, -85.4270439 3>
#>  7 <POLYGON ((-86.4491205 31.971232, -86.4524535 31.8549786, -86.4432903 3>
#>  8 <POLYGON ((-85.793527 33.5634267, -85.7931459 33.5948208, -85.9938349 3>
#>  9 <POLYGON ((-85.5896286 32.7313467, -85.5947808 33.114252, -85.2335029 3>
#> 10 <POLYGON ((-85.4165672 34.0869204, -85.3957378 33.9598293, -85.4861867 >
#> # ℹ 90 more rows
```

<sup>Created on 2024-02-04 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>