### PR TITLE
fix: Ensure `st_crs()` maps to a missing GeoArrow CRS

### DIFF
--- a/R/type.R
+++ b/R/type.R
@@ -297,7 +297,7 @@ na_extension_metadata_internal <- function(crs, edges) {
 }
 
 sanitize_crs <- function(crs = NULL) {
-  if (is.null(crs)) {
+  if (is.null(crs) || isTRUE(try(is.na(crs), silent = TRUE))) {
     return(list(crs_type = enum$CrsType$NONE, crs = ""))
   }
 

--- a/tests/testthat/test-pkg-sf.R
+++ b/tests/testthat/test-pkg-sf.R
@@ -12,6 +12,16 @@ test_that("st_as_sfc() works for geoarrow_vctr()", {
   )
 })
 
+test_that("st_crs() is converted to missing geoarrow crs", {
+  skip_if_not_installed("sf")
+
+  empty_crs_sfc <- sf::st_sfc(sf::st_point(c(0, 1)))
+  schema <- infer_geoarrow_schema(empty_crs_sfc)
+  schema_parsed <- geoarrow_schema_parse(schema)
+  expect_identical(schema_parsed$crs, "")
+  expect_identical(schema_parsed$crs_type, enum$CrsType$NONE)
+})
+
 test_that("arrow package objects can be converted to and from sf objects", {
   skip_if_not_installed("sf")
   skip_if_not_installed("arrow")


### PR DESCRIPTION
Fixes #56 

``` r
library(geoarrow)

(vctr <- as_geoarrow_vctr(sf::st_sfc(sf::st_point(c(0, 1)))))
#> <geoarrow_vctr geoarrow.point{struct}[1]>
#> [1] <POINT (0 1)>
geoarrow_schema_parse(vctr)
#> $id
#> [1] 1
#> 
#> $geometry_type
#> [1] 1
#> 
#> $dimensions
#> [1] 1
#> 
#> $coord_type
#> [1] 1
#> 
#> $extension_name
#> [1] "geoarrow.point"
#> 
#> $crs_type
#> [1] 0
#> 
#> $crs
#> [1] ""
#> 
#> $edge_type
#> [1] 0
```

<sup>Created on 2025-03-04 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>