### PR TITLE
fix: Apply precision when converting sfc objects to geoarrow

### DIFF
--- a/src/r-sf-compat.c
+++ b/src/r-sf-compat.c
@@ -104,7 +104,8 @@ static inline int builder_append_sfg(SEXP item, struct GeoArrowBuilder* builder,
   return GEOARROW_OK;
 }
 
-static inline int builder_append_sfc_point(SEXP sfc, struct GeoArrowBuilder* builder) {
+static inline int builder_append_sfc_point(SEXP sfc, struct GeoArrowBuilder* builder,
+                                           double precision) {
   R_xlen_t n = Rf_xlength(sfc);
 
   for (int i = 0; i < builder->view.coords.n_values; i++) {
@@ -124,7 +125,7 @@ static inline int builder_append_sfc_point(SEXP sfc, struct GeoArrowBuilder* bui
         break;
       }
 
-      builder->view.coords.values[j][i] = item[j];
+      builder->view.coords.values[j][i] = make_precise(item[j], precision);
     }
 
     // Fill dimensions in builder but not in sfc with nan
@@ -141,7 +142,7 @@ static inline int builder_append_sfc_point(SEXP sfc, struct GeoArrowBuilder* bui
 static int builder_append_sfc(SEXP sfc, struct GeoArrowBuilder* builder,
                               double precision) {
   if (Rf_inherits(sfc, "sfc_POINT")) {
-    return builder_append_sfc_point(sfc, builder);
+    return builder_append_sfc_point(sfc, builder, precision);
   }
 
   R_xlen_t n = Rf_xlength(sfc);

--- a/tests/testthat/test-pkg-sf.R
+++ b/tests/testthat/test-pkg-sf.R
@@ -238,6 +238,26 @@ test_that("as_nanoarrow_array() works for sfc_POINT", {
   )
 })
 
+test_that("as_nanoarrow_array() works for sfc_POINT with precision", {
+  skip_if_not_installed("sf")
+
+  sfc <- sf::st_sfc(
+    sf::st_point(c(1.33333333, 2.3333333)),
+    sf::st_point(c(3.33333333, 4.3333333))
+  )
+  sf::st_precision(sfc) <- 100
+
+  array <- as_nanoarrow_array(sfc)
+  expect_identical(
+    as.raw(array$children[[1]]$buffers[[2]]),
+    as.raw(nanoarrow::as_nanoarrow_buffer(c(1.33, 3.33)))
+  )
+  expect_identical(
+    as.raw(array$children[[2]]$buffers[[2]]),
+    as.raw(nanoarrow::as_nanoarrow_buffer(c(2.33, 4.33)))
+  )
+})
+
 test_that("as_nanoarrow_array() works for sfc_POINT with mixed XYZ dimensions", {
   skip_if_not_installed("sf")
 
@@ -299,6 +319,27 @@ test_that("as_nanoarrow_array() works for sfc_LINESTRING", {
   expect_identical(
     as.raw(array$children[[1]]$children[[2]]$buffers[[2]]),
     as.raw(nanoarrow::as_nanoarrow_buffer(c(2, 4)))
+  )
+})
+
+test_that("as_nanoarrow_array() works for sfc_LINESTRING with precision", {
+  skip_if_not_installed("sf")
+
+  sfc <- sf::st_sfc(
+    sf::st_linestring(
+      rbind(c(1.3333333, 2.33333333), c(3.3333333, 4.3333333))
+    )
+  )
+  sf::st_precision(sfc) <- 100
+
+  array <- as_nanoarrow_array(sfc)
+  expect_identical(
+    as.raw(array$children[[1]]$children[[1]]$buffers[[2]]),
+    as.raw(nanoarrow::as_nanoarrow_buffer(c(1.33, 3.33)))
+  )
+  expect_identical(
+    as.raw(array$children[[1]]$children[[2]]$buffers[[2]]),
+    as.raw(nanoarrow::as_nanoarrow_buffer(c(2.33, 4.33)))
   )
 })
 


### PR DESCRIPTION
Closes #55 

``` r
library(sf)
#> Linking to GEOS 3.11.0, GDAL 3.5.3, PROJ 9.1.0; sf_use_s2() is TRUE
library(geoarrow)

sfc = st_point(c(1/3, 1/6)) |>
  st_sfc() |>
  st_set_precision(100)

brew_geoarrow = sfc |>
  geoarrow::as_geoarrow_array()

brew_geoarrow$children$x$buffers[[2]] |> as.vector()
#> [1] 0.33


# Unfortunately geoarrow.wkb will still be inappropriately precisioned
# because this isn't handled in wk
sfc |>wk::as_wkb()
#> <wk_wkb[1] with CRS=NA>
#> [1] <POINT (0.3333333 0.1666667)>
```

<sup>Created on 2025-03-07 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>