### PR TITLE
feat: Support view types in R bindings

### DIFF
--- a/R/type.R
+++ b/R/type.R
@@ -56,6 +56,26 @@ na_extension_large_wkt <- function(crs = NULL, edges = "PLANAR") {
 
 #' @rdname na_extension_wkb
 #' @export
+na_extension_wkb_view <- function(crs = NULL, edges = "PLANAR") {
+  na_extension_geoarrow_internal(
+    enum$Type$WKB_VIEW,
+    crs = crs,
+    edges = edges
+  )
+}
+
+#' @rdname na_extension_wkb
+#' @export
+na_extension_wkt_view <- function(crs = NULL, edges = "PLANAR") {
+  na_extension_geoarrow_internal(
+    enum$Type$WKT_VIEW,
+    crs = crs,
+    edges = edges
+  )
+}
+
+#' @rdname na_extension_wkb
+#' @export
 na_extension_geoarrow <- function(geometry_type, dimensions = "XY",
                                   coord_type = "SEPARATE",
                                   crs = NULL, edges = "PLANAR") {
@@ -120,6 +140,30 @@ geoarrow_large_wkb <- function(crs = NULL, edges = "PLANAR") {
 geoarrow_large_wkt <- function(crs = NULL, edges = "PLANAR") {
   nanoarrow::nanoarrow_vctr(
     na_extension_large_wkt(
+      crs = crs,
+      edges = edges
+    ),
+    subclass = "geoarrow_vctr"
+  )
+}
+
+#' @rdname geoarrow_wkb
+#' @export
+geoarrow_wkb_view <- function(crs = NULL, edges = "PLANAR") {
+  nanoarrow::nanoarrow_vctr(
+    na_extension_wkb_view(
+      crs = crs,
+      edges = edges
+    ),
+    subclass = "geoarrow_vctr"
+  )
+}
+
+#' @rdname geoarrow_wkb
+#' @export
+geoarrow_wkt_view <- function(crs = NULL, edges = "PLANAR") {
+  nanoarrow::nanoarrow_vctr(
+    na_extension_wkt_view(
       crs = crs,
       edges = edges
     ),
@@ -351,7 +395,9 @@ enum <- list(
     WKB = 100001L,
     LARGE_WKB = 100002L,
     WKT = 100003L,
-    LARGE_WKT = 100004L
+    LARGE_WKT = 100004L,
+    WKB_VIEW = 100005L,
+    WKT_VIEW = 100006L
   ),
   GeometryType = list(
     GEOMETRY = 0L,

--- a/src/geoarrow/geoarrow.h
+++ b/src/geoarrow/geoarrow.h
@@ -330,6 +330,9 @@ enum GeoArrowType {
   GEOARROW_TYPE_WKT = 100003,
   GEOARROW_TYPE_LARGE_WKT = 100004,
 
+  GEOARROW_TYPE_WKB_VIEW = 100005,
+  GEOARROW_TYPE_WKT_VIEW = 100006,
+
   GEOARROW_TYPE_BOX = 990,
   GEOARROW_TYPE_BOX_Z = 1990,
   GEOARROW_TYPE_BOX_M = 2990,
@@ -1571,6 +1574,8 @@ static inline enum GeoArrowGeometryType GeoArrowGeometryTypeFromType(
     case GEOARROW_TYPE_LARGE_WKB:
     case GEOARROW_TYPE_WKT:
     case GEOARROW_TYPE_LARGE_WKT:
+    case GEOARROW_TYPE_WKB_VIEW:
+    case GEOARROW_TYPE_WKT_VIEW:
       return GEOARROW_GEOMETRY_TYPE_GEOMETRY;
 
     default:
@@ -1598,9 +1603,11 @@ static inline const char* GeoArrowExtensionNameFromType(enum GeoArrowType type) 
   switch (type) {
     case GEOARROW_TYPE_WKB:
     case GEOARROW_TYPE_LARGE_WKB:
+    case GEOARROW_TYPE_WKB_VIEW:
       return "geoarrow.wkb";
     case GEOARROW_TYPE_WKT:
     case GEOARROW_TYPE_LARGE_WKT:
+    case GEOARROW_TYPE_WKT_VIEW:
       return "geoarrow.wkt";
 
     default:
@@ -1711,8 +1718,10 @@ static inline enum GeoArrowDimensions GeoArrowDimensionsFromType(enum GeoArrowTy
     case GEOARROW_TYPE_UNINITIALIZED:
     case GEOARROW_TYPE_WKB:
     case GEOARROW_TYPE_LARGE_WKB:
+    case GEOARROW_TYPE_WKB_VIEW:
     case GEOARROW_TYPE_WKT:
     case GEOARROW_TYPE_LARGE_WKT:
+    case GEOARROW_TYPE_WKT_VIEW:
       return GEOARROW_DIMENSIONS_UNKNOWN;
 
     default:

--- a/src/geoarrow/geoarrow.hpp
+++ b/src/geoarrow/geoarrow.hpp
@@ -418,6 +418,10 @@ class GeometryDataType {
       modifiers.push_back("large");
     }
 
+    if (id() == GEOARROW_TYPE_WKT_VIEW || id() == GEOARROW_TYPE_WKB_VIEW) {
+      modifiers.push_back("view");
+    }
+
     if (edge_type() != GEOARROW_EDGE_TYPE_PLANAR) {
       modifiers.push_back(GeoArrowEdgeTypeString(edge_type()));
     }

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -10,6 +10,11 @@ test_that("nanoarrow_schema can be created for serialized types", {
   expect_identical(schema_large_wkb$metadata[["ARROW:extension:name"]], "geoarrow.wkb")
   expect_identical(schema_large_wkb$metadata[["ARROW:extension:metadata"]], "{}")
 
+  schema_wkb_view <- na_extension_wkb_view()
+  expect_identical(schema_wkb_view$format, "vz")
+  expect_identical(schema_wkb_view$metadata[["ARROW:extension:name"]], "geoarrow.wkb")
+  expect_identical(schema_wkb_view$metadata[["ARROW:extension:metadata"]], "{}")
+
   schema_wkt <- na_extension_wkt()
   expect_identical(schema_wkt$format, "u")
   expect_identical(schema_wkt$metadata[["ARROW:extension:name"]], "geoarrow.wkt")
@@ -19,6 +24,11 @@ test_that("nanoarrow_schema can be created for serialized types", {
   expect_identical(schema_large_wkt$format, "U")
   expect_identical(schema_large_wkt$metadata[["ARROW:extension:name"]], "geoarrow.wkt")
   expect_identical(schema_large_wkt$metadata[["ARROW:extension:metadata"]], "{}")
+
+  schema_wkt_view <- na_extension_wkt_view()
+  expect_identical(schema_wkt_view$format, "vu")
+  expect_identical(schema_wkt_view$metadata[["ARROW:extension:name"]], "geoarrow.wkt")
+  expect_identical(schema_wkt_view$metadata[["ARROW:extension:metadata"]], "{}")
 })
 
 test_that("nanoarrow_schema can be created for native types", {

--- a/vendor-geoarrow.sh
+++ b/vendor-geoarrow.sh
@@ -1,7 +1,7 @@
 
 rm src/geoarrow*
 
-GEOARROW_C_REF="5234b187523497bac5a163ecdd51108401bf8c40"
+GEOARROW_C_REF="4fa3a2c4fefd4d8bad4182e747c76c2278b40a2c"
 
 curl -L \
     "https://github.com/geoarrow/geoarrow-c/archive/${GEOARROW_C_REF}.zip" \


### PR DESCRIPTION
Fairly basic, but works for consuming and basic generation:

``` r
library(geoarrow)

vctr <- as_geoarrow_vctr(wk::wkt("POINT (0 1)"), schema = geoarrow_wkt_view())

as_geoarrow_vctr(vctr, schema = geoarrow_wkb())
#> <geoarrow_vctr geoarrow.wkb{binary}[1]>
#> [1] <POINT (0 1)>
```

<sup>Created on 2025-05-26 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>