### PR TITLE
chore: Update vendored nanoarrow

### DIFF
--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -21,7 +21,7 @@
 #define NANOARROW_VERSION_MAJOR 0
 #define NANOARROW_VERSION_MINOR 7
 #define NANOARROW_VERSION_PATCH 0
-#define NANOARROW_VERSION "0.7.0-SNAPSHOT"
+#define NANOARROW_VERSION "0.7.0"
 
 #define NANOARROW_VERSION_INT                                        \
   (NANOARROW_VERSION_MAJOR * 10000 + NANOARROW_VERSION_MINOR * 100 + \
@@ -1236,7 +1236,7 @@ static inline void ArrowDecimalSetBytes(struct ArrowDecimal* decimal,
 #define NANOARROW_DLL __declspec(dllimport)
 #endif  // defined(NANOARROW_EXPORT_DLL)
 #elif !defined(NANOARROW_DLL)
-#if __GNUC__ >= 4
+#if defined(__GNUC__) && __GNUC__ >= 4
 #define NANOARROW_DLL __attribute__((visibility("default")))
 #else
 #define NANOARROW_DLL

--- a/vendor-nanoarrow.sh
+++ b/vendor-nanoarrow.sh
@@ -1,7 +1,7 @@
 main() {
   local -r repo_url="https://github.com/apache/arrow-nanoarrow"
   # Check releases page: https://github.com/apache/arrow-nanoarrow/releases/
-  local -r commit_sha=fe0e3a2745952c7bd415fdf09bda2a869bf1390a
+  local -r commit_sha=2cfba631b40886f1418a463f3b7c4552c8ae0dc7
 
   echo "Fetching $commit_sha from $repo_url"
   SCRATCH=$(mktemp -d)


### PR DESCRIPTION
Updates the internal version of nanoarrow to 0.7.0.